### PR TITLE
fix testing_release_with_qa workflow (bis)

### DIFF
--- a/.github/workflows/testing-release-with-qa-test-job.yml
+++ b/.github/workflows/testing-release-with-qa-test-job.yml
@@ -182,16 +182,18 @@ jobs:
             #runner: ubuntu-latest-devops-large
             runner-arch: X64
             artifact: linux_amd64v2
-          - id: linux/arm64
-            #runner: ubuntu-latest-release-test-arm64
-            #runner: ubuntu-latest-devops-large-arm
-            runner-arch: ARM64
-            artifact: linux_arm64
+          #- id: linux/arm64
+          #  #runner: ubuntu-latest-release-test-arm64
+          #  #runner: ubuntu-latest-devops-large-arm
+          #  runner-arch: ARM64
+          #  artifact: linux_arm64
                     
 
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Download artifact ${{ env.APPLICATION }}_${{ inputs.release_version }}_${{ matrix.artifact }}.tar.gz
         uses: actions/download-artifact@v4


### PR DESCRIPTION
With only two runners, we can only run two tests in parallel otherwise 
- we would have to wait twice as long and 
- one of the test jobs would fail due to the queuing timeout.

Also, there was a failure because the github token expired, I think it is the token from the secret. 
@lystopad you should extend its duration